### PR TITLE
Update semantic-release changelog options

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         run: npm -g install semantic-release
 
       - name: Install semantic-release plugins
-        run: npm install -g $(jq -r '.plugins[]' .releaserc.json | grep -o '@semantic-release/[a-zA-Z0-9-]*')
+        run: npm install -g $(jq -r '.plugins[]' .releaserc.json | grep -o '@semantic-release/[a-zA-Z0-9-]*') conventional-changelog-conventionalcommits
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,63 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "revert": true, "release": "patch" },
+          { "type": "chore", "release": false },
+          { "type": "ci", "release": false },
+          { "type": "docs", "release": false },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "<!-- 1. -->:rocket: New Features",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "<!-- 2. -->:bug: Bug Fixes",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": "<!-- 3. -->:chart_with_upwards_trend: Performance Improvements",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": "<!-- 4. -->:tractor: Refactor",
+              "hidden": false
+            },
+            {
+              "type": "docs",
+              "section": "<!-- 5. -->:memo: Documentation",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "section": "<!-- 6. -->:broom: Chore",
+              "hidden": false
+            }
+          ]
+        }
+      }
+    ],
     "@semantic-release/changelog",
     [
       "@semantic-release/git",


### PR DESCRIPTION
This PR improves the `semantic-release` changelog generator format and adds support for more commit types.
An example of releases that were created using this format can be found here: https://github.com/roeizavida/fluffy-fiesta/releases