### PR TITLE
fix: Fix typo in CONTRIBUTING.md and build.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ open docs/_build/html/index.html
 Before committing any new code change, please run the full test suite to ensure its quality and coverage. To do this, please run
 
 ```sh
-./script/test.sh
+./scripts/test.sh
 ```
 
 You can run the script directly by running the following: `Poetry run pytest`

--- a/docs/how_to_guides/custom_extractor.rst
+++ b/docs/how_to_guides/custom_extractor.rst
@@ -14,11 +14,11 @@ Let’s create IsPalindromeExtractor that will return if the given text is palin
 
 ::
 
-    >>> class IsPalindromeExtractor(AbstractMetadataExtractor):
+    >>> class IsPalindromeExtractor(AbstractMetafeatureExtractor):
     ...     def extract(self, text: str) -> bool:
     ...         normalized_text = text.replace(" ", "").lower()
     ...         return normalized_text == normalized_text[::-1]
-    >>> ipe = IsPlindromExtractor()
+    >>> ipe = IsPalindromeExtractor()
 
 Let’s test it:
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,5 @@
 
 poetry check
 poetry lock --no-update
-poetry install --only root
+poetry install --only-root
 poetry build


### PR DESCRIPTION
fixed typos allowing one of the how_to_guides in the documentation to actually run. As well as another typo in the build script.